### PR TITLE
PAPlayer/Audioengine tweaks for spotyxbmc

### DIFF
--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -900,6 +900,16 @@ bool CFileItem::IsRemovable() const
   return IsOnDVD() || IsCDDA() || m_iDriveType == CMediaSource::SOURCE_TYPE_REMOVABLE;
 }
 
+bool CFileItem::IsSpotify() const
+{
+  if (URIUtils::GetExtension(m_strPath).Equals(".spotify", false))
+    return true;
+  CStdString extension = m_strPath.Right(m_strPath.GetLength() - m_strPath.Find('.') - 1);
+  if (extension.Left(12) == "spotifyradio")
+    return true;
+  return false;
+}
+
 bool CFileItem::IsReadOnly() const
 {
   if (IsParentFolder()) return true;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -140,6 +140,7 @@ public:
   bool IsParentFolder() const;
   bool IsFileFolder() const;
   bool IsRemovable() const;
+  bool IsSpotify() const;
   bool IsTuxBox() const;
   bool IsMythTV() const;
   bool IsHDHomeRun() const;

--- a/xbmc/cores/paplayer/PAPlayer.cpp
+++ b/xbmc/cores/paplayer/PAPlayer.cpp
@@ -40,6 +40,7 @@
 #define TIME_TO_CACHE_NEXT_FILE 5000 /* 5 seconds before end of song, start caching the next song */
 #define FAST_XFADE_TIME           80 /* 80 milliseconds */
 #define MAX_SKIP_XFADE_TIME     2000 /* max 2 seconds crossfade on track skip */
+/* Spotify hack !! When changing defines above, also do it OpenFile and QueueNextFileEx below */
 
 CAEChannelInfo ICodec::GetChannelInfo()
 {
@@ -232,7 +233,26 @@ void PAPlayer::CloseAllStreams(bool fade/* = true */)
 
 bool PAPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options)
 {
-  m_defaultCrossfadeMS = g_guiSettings.GetInt("musicplayer.crossfade") * 1000;
+  if (!file.IsSpotify())
+  {
+    m_defaultCrossfadeMS = g_guiSettings.GetInt("musicplayer.crossfade") * 1000;
+    #undef TIME_TO_CACHE_NEXT_FILE //Ensure we have default values
+    #undef FAST_XFADE_TIME
+    #undef MAX_SKIP_XFADE_TIME
+    #define TIME_TO_CACHE_NEXT_FILE 5000
+    #define FAST_XFADE_TIME           80
+    #define MAX_SKIP_XFADE_TIME     2000
+  }
+  else
+  {
+    m_defaultCrossfadeMS = 0;
+    #undef TIME_TO_CACHE_NEXT_FILE
+    #undef FAST_XFADE_TIME
+    #undef MAX_SKIP_XFADE_TIME
+    #define TIME_TO_CACHE_NEXT_FILE 0000
+    #define FAST_XFADE_TIME           00
+    #define MAX_SKIP_XFADE_TIME     0000
+  }
 
   if (m_streams.size() > 1 || !m_defaultCrossfadeMS)
   {
@@ -266,7 +286,14 @@ bool PAPlayer::OpenFile(const CFileItem& file, const CPlayerOptions &options)
 
 void PAPlayer::UpdateCrossfadeTime(const CFileItem& file)
 {
-  m_upcomingCrossfadeMS = m_defaultCrossfadeMS = g_guiSettings.GetInt("musicplayer.crossfade") * 1000;
+  if (!file.IsSpotify())
+    m_upcomingCrossfadeMS = m_defaultCrossfadeMS = g_guiSettings.GetInt("musicplayer.crossfade") * 1000;
+  else
+  {
+    CLog::Log(LOGDEBUG, "PAPlayer::UpdateCrossfadeTime: Spotify track detected, crossfade is disabled.");
+    m_upcomingCrossfadeMS = m_defaultCrossfadeMS; // Spotify (spotyxbmc) can not handle crossfade
+  }
+
   if (m_upcomingCrossfadeMS)
   {
     if (m_streams.size() == 0 ||
@@ -293,6 +320,31 @@ bool PAPlayer::QueueNextFile(const CFileItem &file)
 
 bool PAPlayer::QueueNextFileEx(const CFileItem &file, bool fadeIn/* = true */)
 {
+
+  if (!file.IsSpotify())
+  {
+    #undef TIME_TO_CACHE_NEXT_FILE //Make sure we have default values
+    #undef FAST_XFADE_TIME
+    #undef MAX_SKIP_XFADE_TIME
+    #define TIME_TO_CACHE_NEXT_FILE 5000
+    #define FAST_XFADE_TIME           80
+    #define MAX_SKIP_XFADE_TIME     2000
+  }
+  else
+  {
+    m_defaultCrossfadeMS = 0;
+    #undef TIME_TO_CACHE_NEXT_FILE
+    #undef FAST_XFADE_TIME
+    #undef MAX_SKIP_XFADE_TIME
+    #define TIME_TO_CACHE_NEXT_FILE 0000
+    #define FAST_XFADE_TIME           00
+    #define MAX_SKIP_XFADE_TIME     0000
+    do  //Make sure we only have one concurrent spotifyc stream
+    {
+      CThread::Sleep(5); //Always execute at least once to allow stream to close
+    } while((m_streams.size() > 0) && (m_playerGUIData.m_codec == "spotify"));
+  }
+
   StreamInfo *si = new StreamInfo();
 
   if (!si->m_decoder.Create(file, (file.m_lStartOffset * 1000) / 75))


### PR DESCRIPTION
This pull request fixes the following issues:

1)
In xbmc.log
CAudioDecoder: Unable to Init Codec while loading file

and

QueueNextFileEx - Failed to create the decoder

2)
The last 5 seconds of spotify songs was never played.
PAplayer attempted to cache next song, but spotify codec already does that internally.
Because spotify codec only allow one stream at any given time, the caching start aborted the currently played song.

3)
Clicking skipnext to start the next song in a playlist did not work. This occured because PAplayer wanted to open a new stream before the other stream was closed.

4)
When user had crossfade enabled, xbmc behaved strange.
Now PAplayer internally disables crossfade only for spotify songs so XBMC will not crossfade spotify songs even when user have this setting enabled. Other media will still crossfade. Crossfading does not work with spotify songs because spotify codec only allows one open stream at any given time. 

If crossfading ever gets implemented in spotyxbmc, see issue 12, this pull request should be reverted.
https://github.com/akezeke/spotyxbmc2/issues/12

Basically, since the audioengine merge, PAplayer always mixes streams with a small overlap of 80ms (crossfading). Difference in PAplayer when user have enabled crossfade is the crossfading time gets much longer (seconds).  So this pull request is needed because we hit issue 12 all the time.
