### PR TITLE
read appkey at runtime

### DIFF
--- a/xbmc/music/spotyXBMC/SxSettings.cpp
+++ b/xbmc/music/spotyXBMC/SxSettings.cpp
@@ -192,12 +192,14 @@ namespace addon_music_spotify {
     *appkey = malloc(size + 1);
     if (*appkey == NULL) {
       Logger::printOut("Failed to allocate memory for appkey");
+      fclose(f);
       return 0;
     }
 
     if (fread(*appkey, 1, size, f) != size) {
       Logger::printOut("Failed to read spotify appkey file:");
       Logger::printOut(path);
+      fclose(f);
       *appkey = NULL;
       return 0;
     }

--- a/xbmc/music/spotyXBMC/SxSettings.cpp
+++ b/xbmc/music/spotyXBMC/SxSettings.cpp
@@ -167,4 +167,34 @@ namespace addon_music_spotify {
 
     return (sp_radio_genre) mask;
   }
+
+  size_t Settings::getAppKey(uint8_t *appkey[]) {
+    char *path = NULL;
+    FILE *f = NULL;
+    char buf[3];
+    uint8_t tmp[512];
+    int i = 0;
+
+    strcpy (path, CSpecialProtocol::TranslatePath("special://profile/appkey.h").c_str());
+
+    f = fopen(path, "r");
+    if(f == NULL)
+      return 0;
+
+    while (!feof(f)) {
+      if(fgetc(f) == '0' && fgetc(f) == 'x') {
+        if(fgets(buf, 3, f) == NULL)
+		return 0;
+
+        tmp[i++] = strtol(buf, NULL, 16);
+      }
+    }
+
+    fclose(f);
+
+    *appkey = (uint8_t*) realloc(*appkey, i);
+    memcpy(*appkey, tmp, i);
+
+    return i;
+  }
 } /* namespace addon_music_spotify */

--- a/xbmc/music/spotyXBMC/SxSettings.cpp
+++ b/xbmc/music/spotyXBMC/SxSettings.cpp
@@ -172,13 +172,13 @@ namespace addon_music_spotify {
   size_t Settings::getAppKey(void **appkey) {
     char *path;
     FILE *f;
-    int size;
+    size_t size;
 
     path = new char [CSpecialProtocol::TranslatePath("special://profile/spotify_appkey.key").size() + 1];
     strcpy(path, CSpecialProtocol::TranslatePath("special://profile/spotify_appkey.key").c_str());
 
     f = fopen(path, "r");
-    if(f == NULL) {
+    if (f == NULL) {
       Logger::printOut("Failed to open spotify appkey file:");
       Logger::printOut(path);
       *appkey = NULL;
@@ -190,13 +190,12 @@ namespace addon_music_spotify {
     fseek(f, 0, SEEK_SET);
 
     *appkey = malloc(size + 1);
-    if(*appkey == NULL) {
+    if (*appkey == NULL) {
       Logger::printOut("Failed to allocate memory for appkey");
-      *appkey = NULL;
       return 0;
     }
 
-    if(fread(*appkey, 1, size, f) != size) {
+    if (fread(*appkey, 1, size, f) != size) {
       Logger::printOut("Failed to read spotify appkey file:");
       Logger::printOut(path);
       *appkey = NULL;

--- a/xbmc/music/spotyXBMC/SxSettings.cpp
+++ b/xbmc/music/spotyXBMC/SxSettings.cpp
@@ -21,6 +21,7 @@
 
 #include "SxSettings.h"
 #include "URL.h"
+#include "Logger.h"
 
 namespace addon_music_spotify {
 
@@ -175,16 +176,21 @@ namespace addon_music_spotify {
     uint8_t tmp[512];
     int i = 0;
 
-    strcpy (path, CSpecialProtocol::TranslatePath("special://profile/appkey.h").c_str());
+    path = (char*) CSpecialProtocol::TranslatePath("special://profile/appkey.h").c_str();
 
     f = fopen(path, "r");
-    if(f == NULL)
+    if(f == NULL) {
+      Logger::printOut(sprintf("unable to open spotify appkey file '%s'\n", path));
       return 0;
+    }
 
     while (!feof(f)) {
       if(fgetc(f) == '0' && fgetc(f) == 'x') {
-        if(fgets(buf, 3, f) == NULL)
-		return 0;
+        if(fgets(buf, 3, f) == NULL) {
+          Logger::printOut(sprintf("unexpected end of file '%s'\n", path));
+          fclose(f);
+          return 0;
+        }
 
         tmp[i++] = strtol(buf, NULL, 16);
       }
@@ -192,7 +198,7 @@ namespace addon_music_spotify {
 
     fclose(f);
 
-    *appkey = (uint8_t*) realloc(*appkey, i);
+    *appkey = (uint8_t*) malloc(i);
     memcpy(*appkey, tmp, i);
 
     return i;

--- a/xbmc/music/spotyXBMC/SxSettings.h
+++ b/xbmc/music/spotyXBMC/SxSettings.h
@@ -22,6 +22,7 @@
 #ifndef SXSETTINGS_H_
 #define SXSETTINGS_H_
 
+#include <stdint.h>
 #include <libspotify/api.h>
 #include "addons/Addon.h"
 #include "addons/AddonManager.h"
@@ -42,6 +43,8 @@ namespace addon_music_spotify {
     bool enabled() {
       return m_enabled;
     }
+
+    size_t getAppKey(uint8_t *appkey[]);
 
     CStdString getUserName() {
       return m_userName;

--- a/xbmc/music/spotyXBMC/SxSettings.h
+++ b/xbmc/music/spotyXBMC/SxSettings.h
@@ -22,7 +22,6 @@
 #ifndef SXSETTINGS_H_
 #define SXSETTINGS_H_
 
-#include <stdint.h>
 #include <libspotify/api.h>
 #include "addons/Addon.h"
 #include "addons/AddonManager.h"
@@ -44,7 +43,7 @@ namespace addon_music_spotify {
       return m_enabled;
     }
 
-    size_t getAppKey(uint8_t *appkey[]);
+    size_t getAppKey(void **appkey);
 
     CStdString getUserName() {
       return m_userName;

--- a/xbmc/music/spotyXBMC/session/Session.cpp
+++ b/xbmc/music/spotyXBMC/session/Session.cpp
@@ -20,7 +20,6 @@
  */
 
 #include "Session.h"
-#include "../../../../appkey.h"
 #include <string>
 
 #include "../player/PlayerHandler.h"
@@ -86,8 +85,7 @@ namespace addon_music_spotify {
       config.settings_location = cstr;
       config.tracefile = NULL;
 
-      config.application_key = g_appkey;
-      config.application_key_size = g_appkey_size;
+      config.application_key_size = Settings::getInstance()->getAppKey((uint8_t**) &config.application_key);
       config.user_agent = "spotyXBMC2";
       config.device_id = "XBMC htpc";
 

--- a/xbmc/music/spotyXBMC/session/Session.cpp
+++ b/xbmc/music/spotyXBMC/session/Session.cpp
@@ -85,7 +85,7 @@ namespace addon_music_spotify {
       config.settings_location = cstr;
       config.tracefile = NULL;
 
-      config.application_key_size = Settings::getInstance()->getAppKey((uint8_t**) &config.application_key);
+      config.application_key_size = Settings::getInstance()->getAppKey((void**) &config.application_key);
       config.user_agent = "spotyXBMC2";
       config.device_id = "XBMC htpc";
 


### PR DESCRIPTION
add functionality to read appkey at runtime
so it could be published as binary and there is no need to compile it
